### PR TITLE
Re-enable lambda CI

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -4,16 +4,5 @@ steps:
   - label: ":s3:"
     command: ".buildkite/steps/release-version.sh"
     branches: master
-    agents:
-      queue: "deploy-legacy"
-    concurrency: 1
-    concurrency_group: 'release'
-
-  - wait
-  - label: ":github:"
-    command: ".buildkite/steps/github-release.sh"
-    branches: master
-    agents:
-      queue: "deploy-legacy"
     concurrency: 1
     concurrency_group: 'release'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
   - name: ":golang:"
     command: ".buildkite/steps/tests.sh"
     plugins:
-      - docker#v3.1.0:
+      - docker#v3.5.0:
           image: "golang:1.13"
           workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
           environment:
@@ -13,4 +13,17 @@ steps:
   - wait
   - name: ":docker:"
     command: .buildkite/steps/build-docker.sh
-    # branches: master
+
+  - name: ":lambda:"
+    command: .buildkite/steps/build-lambda.sh
+    artifact_paths:
+      - handler.zip
+
+  - wait
+  - label: ":s3:"
+    command: .buildkite/steps/upload-to-s3.sh
+
+  - wait
+  - name: ":pipeline:"
+    command: .buildkite/steps/upload-release-steps.sh
+    branches: master

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,3 @@
-env:
-  SEGMENT_CONTEXTS: 'ecr'
 steps:
   - name: ":golang:"
     command: ".buildkite/steps/tests.sh"
@@ -13,6 +11,8 @@ steps:
   - wait
   - name: ":docker:"
     command: .buildkite/steps/build-docker.sh
+    env:
+      SEGMENT_CONTEXTS: 'ecr'
 
   - name: ":lambda:"
     command: .buildkite/steps/build-lambda.sh
@@ -22,8 +22,12 @@ steps:
   - wait
   - label: ":s3:"
     command: .buildkite/steps/upload-to-s3.sh
+    env:
+      SEGMENT_CONTEXTS: 'aws-credentials'
 
   - wait
   - name: ":pipeline:"
     command: .buildkite/steps/upload-release-steps.sh
     branches: master
+    env:
+      SEGMENT_CONTEXTS: 'aws-credentials'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
+env:
+  SEGMENT_CONTEXTS: 'aws-credentials,ecr'
 steps:
-    env:
-      SEGMENT_CONTEXTS: 'aws-credentials,ecr'
   - name: ":golang:"
     command: ".buildkite/steps/tests.sh"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,6 @@
 steps:
+    env:
+      SEGMENT_CONTEXTS: 'aws-credentials,ecr'
   - name: ":golang:"
     command: ".buildkite/steps/tests.sh"
     plugins:
@@ -11,8 +13,6 @@ steps:
   - wait
   - name: ":docker:"
     command: .buildkite/steps/build-docker.sh
-    env:
-      SEGMENT_CONTEXTS: 'ecr'
 
   - name: ":lambda:"
     command: .buildkite/steps/build-lambda.sh
@@ -22,12 +22,8 @@ steps:
   - wait
   - label: ":s3:"
     command: .buildkite/steps/upload-to-s3.sh
-    env:
-      SEGMENT_CONTEXTS: 'aws-credentials'
 
   - wait
   - name: ":pipeline:"
     command: .buildkite/steps/upload-release-steps.sh
     branches: master
-    env:
-      SEGMENT_CONTEXTS: 'aws-credentials'

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -12,4 +12,4 @@ buildkite-agent artifact download "handler.zip" .
 echo "--- 🚀 Releasing $VERSION"
 github-release "v$VERSION" handler.zip \
   --commit "$(git rev-parse HEAD)" \
-  --github-repository "buildkite/buildkite-agent-scaler"
+  --github-repository "segmentio/buildkite-agent-scaler"

--- a/.buildkite/steps/upload-to-s3.sh
+++ b/.buildkite/steps/upload-to-s3.sh
@@ -5,24 +5,6 @@ export AWS_DEFAULT_REGION=us-west-2
 # export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-$SANDBOX_AWS_ACCESS_KEY_ID}
 # export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-$SANDBOX_AWS_SECRET_ACCESS_KEY}
 
-EXTRA_REGIONS=(
-  # us-east-1
-  # us-west-1
-  # us-west-2
-  # ap-south-1
-  # ap-northeast-2
-  # ap-southeast-1
-  # ap-southeast-2
-  # ap-northeast-1
-  # ca-central-1
-  # eu-central-1
-  # eu-west-1
-  # eu-west-2
-  # eu-west-3
-  # eu-north-1
-  # sa-east-1
-)
-
 VERSION=$(buildkite-agent meta-data get "version")
 BASE_BUCKET=segment-lambdas-ci
 BUCKET_PATH="buildkite-agent-scaler"
@@ -38,9 +20,3 @@ buildkite-agent artifact download handler.zip .
 
 echo "--- :s3: Uploading lambda to ${BASE_BUCKET}/${BUCKET_PATH}/ in ${AWS_DEFAULT_REGION}"
 aws s3 cp handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
-
-for region in "${EXTRA_REGIONS[@]}" ; do
-  bucket="${BASE_BUCKET}-${region}"
-  echo "--- :s3: Copying files to ${bucket}"
-  aws --region "${region}" s3 cp "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip" "s3://${bucket}/${BUCKET_PATH}/handler.zip"
-done

--- a/.buildkite/steps/upload-to-s3.sh
+++ b/.buildkite/steps/upload-to-s3.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eu
 
+# shellcheck disable=SC1090
+source "$SEGMENT_LIB_PATH/aws.bash"
+
 export AWS_DEFAULT_REGION=us-west-2
 # export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-$SANDBOX_AWS_ACCESS_KEY_ID}
 # export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-$SANDBOX_AWS_SECRET_ACCESS_KEY}
@@ -15,8 +18,12 @@ else
   BUCKET_PATH="${BUCKET_PATH}/builds/${BUILDKITE_BUILD_NUMBER}"
 fi
 
+function do-upload() {
+  echo "--- :s3: Uploading lambda to ${BASE_BUCKET}/${BUCKET_PATH}/ in ${AWS_DEFAULT_REGION}"
+  aws s3 cp handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
+}
+
 echo "~~~ :buildkite: Downloading artifacts"
 buildkite-agent artifact download handler.zip .
 
-echo "--- :s3: Uploading lambda to ${BASE_BUCKET}/${BUCKET_PATH}/ in ${AWS_DEFAULT_REGION}"
-aws s3 cp handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
+run-with-role "default" do-upload

--- a/.buildkite/steps/upload-to-s3.sh
+++ b/.buildkite/steps/upload-to-s3.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 set -eu
 
-export AWS_DEFAULT_REGION=us-east-1
+export AWS_DEFAULT_REGION=us-west-2
 # export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-$SANDBOX_AWS_ACCESS_KEY_ID}
 # export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-$SANDBOX_AWS_SECRET_ACCESS_KEY}
 
 EXTRA_REGIONS=(
-  us-east-2
-  us-west-1
-  us-west-2
-  ap-south-1
-  ap-northeast-2
-  ap-southeast-1
-  ap-southeast-2
-  ap-northeast-1
-  ca-central-1
-  eu-central-1
-  eu-west-1
-  eu-west-2
-  eu-west-3
-  eu-north-1
-  sa-east-1
+  # us-east-1
+  # us-west-1
+  # us-west-2
+  # ap-south-1
+  # ap-northeast-2
+  # ap-southeast-1
+  # ap-southeast-2
+  # ap-northeast-1
+  # ca-central-1
+  # eu-central-1
+  # eu-west-1
+  # eu-west-2
+  # eu-west-3
+  # eu-north-1
+  # sa-east-1
 )
 
 VERSION=$(buildkite-agent meta-data get "version")
-BASE_BUCKET=buildkite-lambdas
+BASE_BUCKET=segment-lambdas-ci
 BUCKET_PATH="buildkite-agent-scaler"
 
 if [[ "${1:-}" == "release" ]] ; then
@@ -37,10 +37,10 @@ echo "~~~ :buildkite: Downloading artifacts"
 buildkite-agent artifact download handler.zip .
 
 echo "--- :s3: Uploading lambda to ${BASE_BUCKET}/${BUCKET_PATH}/ in ${AWS_DEFAULT_REGION}"
-aws s3 cp --acl public-read handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
+aws s3 cp handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
 
 for region in "${EXTRA_REGIONS[@]}" ; do
-	bucket="${BASE_BUCKET}-${region}"
-	echo "--- :s3: Copying files to ${bucket}"
-	aws --region "${region}" s3 cp --acl public-read "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip" "s3://${bucket}/${BUCKET_PATH}/handler.zip"
+  bucket="${BASE_BUCKET}-${region}"
+  echo "--- :s3: Copying files to ${bucket}"
+  aws --region "${region}" s3 cp "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip" "s3://${bucket}/${BUCKET_PATH}/handler.zip"
 done

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ clean:
 # -----------------------------------------
 # Lambda management
 
-LAMBDA_S3_BUCKET := buildkite-aws-stack-lox
-LAMBDA_S3_BUCKET_PATH := /
+LAMBDA_S3_BUCKET := segment-lambdas-ci
+LAMBDA_S3_BUCKET_PATH := /buildkite-agent-scaler
 
 ifdef BUILDKITE_BUILD_NUMBER
 	LD_FLAGS := -s -w -X version.Build=$(BUILDKITE_BUILD_NUMBER)
@@ -29,7 +29,7 @@ lambda/handler: lambda/main.go
 		--volume go-module-cache:/go/pkg/mod \
 		--volume $(PWD):/go/src/github.com/buildkite/buildkite-agent-scaler \
 		--workdir /go/src/github.com/buildkite/buildkite-agent-scaler \
-		--rm golang:1.12 \
+		--rm golang:1.13 \
 		go build -ldflags="$(LD_FLAGS)" -o ./lambda/handler ./lambda
 	chmod +x lambda/handler
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ lambda/handler: lambda/main.go
 		--workdir /go/src/github.com/buildkite/buildkite-agent-scaler \
 		--rm golang:1.13 \
 		go build -ldflags="$(LD_FLAGS)" -o ./lambda/handler ./lambda
-	chmod +x lambda/handler
 
 lambda-sync: handler.zip
 	aws s3 sync \

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version the library version number
-const Version = "1.0.1"
+const Version = "1.0.1-segment"
 
 // The build number
 var Build string


### PR DESCRIPTION
We're going to deploy this as a lambda so this sets up CI to create new releases of the lambda and upload them to S3. We might even be able to get away with using the public builds provided in the upstream, but for now we're keeping a fork.