### PR TITLE
Prevent desired count from going outside of min/max after factoring

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -6,14 +6,5 @@ steps:
   - label: ":s3:"
     command: ".buildkite/steps/release-version.sh"
     branches: master
-    agents:
-      queue: "deploy"
     concurrency: 1
     concurrency_group: 'release'
-
-  - wait
-  - label: ":github:"
-    command: ".buildkite/steps/github-release.sh"
-    branches: master
-    agents:
-      queue: "deploy"

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -177,6 +177,11 @@ func (s *Scaler) scaleIn(desired int64, current AutoscaleGroupDetails) error {
 		desired = 0
 	}
 
+	if desired < current.MinSize {
+		log.Printf("⚠️  Factored desired count is less than MinSize, capping at %d", current.MinSize)
+		desired = current.MinSize
+	}
+
 	log.Printf("Scaling IN 📉 to %d instances (currently %d)", desired, current.DesiredCount)
 
 	if err := s.setDesiredCapacity(desired); err != nil {
@@ -222,6 +227,11 @@ func (s *Scaler) scaleOut(desired int64, current AutoscaleGroupDetails) error {
 		}
 
 		desired = current.DesiredCount + factoredChange
+	}
+
+	if desired > current.MaxSize {
+		log.Printf("⚠️  Factored desired count exceed MaxSize, capping at %d", current.MaxSize)
+		desired = current.MaxSize
 	}
 
 	log.Printf("Scaling OUT 📈 to %d instances (currently %d)", desired, current.DesiredCount)

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version the library version number
-const Version = "1.0.1-segment"
+const Version = "1.0.2-segment"
 
 // The build number
 var Build string


### PR DESCRIPTION
There's an issue such that if there is a scaling factor applied, the desired count can be outside the ASG min/max and thus result in an API error and a failed scaling event. From our logs:
```
2020/03/12 00:56:56 Collecting agent metrics for queue "alpha"
2020/03/12 00:56:56 ↳ Got scheduled=26, running=3, waiting=0 (took 112.881298ms)
2020/03/12 00:56:56 ⚠️  Desired count exceed MaxSize, capping at 10
2020/03/12 00:56:56 👮‍️ Increasing scale-out of 7 by factor of 1.50
2020/03/12 00:56:56 Scaling OUT 📈 to 14 instances (currently 3)
2020/03/12 00:56:57 Scaling error: ValidationError: New SetDesiredCapacity value 14 is above max value 10 for the AutoScalingGroup.
	status code: 400, request id: 50c4d0f3-e8bd-4ab4-9284-ea3fdd85b125
2020/03/12 00:56:57 Waiting for 10s
```

I added tests to demonstrate the issue as well.
