### PR TITLE
Bumping version to 1.0.4-segment

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version the library version number
-const Version = "1.0.3-segment"
+const Version = "1.0.4-segment"
 
 // The build number
 var Build string


### PR DESCRIPTION
This is completely missing from our documentation https://segment.atlassian.net/wiki/spaces/INFRA/pages/1996259341/Buildkite+System+Release+Pipeline#Lambdas.1 and when I actually finish releasing this newest version successfully I'll go back and edit this page